### PR TITLE
feat: Allow post verify actions.

### DIFF
--- a/store_redis_test.go
+++ b/store_redis_test.go
@@ -1,6 +1,7 @@
 package passwordless
 
 import (
+	"context"
 	"log"
 	"testing"
 	"time"
@@ -25,7 +26,7 @@ func newRedisMock() *redisMock {
 	}
 }
 
-func (r redisMock) Set(key string, value interface{}, expiration time.Duration) *redis.StatusCmd {
+func (r redisMock) Set(ctx context.Context, key string, value interface{}, expiration time.Duration) *redis.StatusCmd {
 	val := rval{
 		d: expiration,
 	}
@@ -37,7 +38,7 @@ func (r redisMock) Set(key string, value interface{}, expiration time.Duration) 
 	return redis.NewStatusResult(key, nil)
 }
 
-func (r redisMock) TTL(key string) *redis.DurationCmd {
+func (r redisMock) TTL(ctx context.Context, key string) *redis.DurationCmd {
 	v, ok := r.store[key]
 	if !ok {
 		return redis.NewDurationResult(-1*time.Second, nil)
@@ -46,7 +47,7 @@ func (r redisMock) TTL(key string) *redis.DurationCmd {
 	return cmd
 }
 
-func (r redisMock) Get(key string) *redis.StringCmd {
+func (r redisMock) Get(ctx context.Context, key string) *redis.StringCmd {
 	v, ok := r.store[key]
 	if !ok {
 		return redis.NewStringResult("", redis.Nil)
@@ -58,7 +59,7 @@ func (r redisMock) Get(key string) *redis.StringCmd {
 	return redis.NewStringResult(v.v, nil)
 }
 
-func (r redisMock) Del(keys ...string) *redis.IntCmd {
+func (r redisMock) Del(ctx context.Context, keys ...string) *redis.IntCmd {
 	for _, k := range keys {
 		delete(r.store, k)
 	}
@@ -66,50 +67,56 @@ func (r redisMock) Del(keys ...string) *redis.IntCmd {
 }
 
 func TestRedisStore(t *testing.T) {
+	ctx := context.TODO()
 	ms := NewRedisStore(newRedisMock())
 	assert.NotNil(t, ms)
 
-	b, exp, err := ms.Exists(nil, "uid")
+	b, exp, err := ms.Exists(ctx, "uid")
 	assert.False(t, b)
 	assert.True(t, exp.IsZero())
 	assert.NoError(t, err)
 
-	err = ms.Store(nil, "", "uid", -time.Hour)
-	b, exp, err = ms.Exists(nil, "uid")
+	err = ms.Store(ctx, "", "uid", -time.Hour)
+	assert.NoError(t, err)
+	b, exp, err = ms.Exists(ctx, "uid")
 	assert.False(t, b)
 	assert.True(t, exp.IsZero())
 	assert.NoError(t, err)
 
-	err = ms.Store(nil, "", "uid", time.Hour)
-	b, exp, err = ms.Exists(nil, "uid")
+	err = ms.Store(ctx, "", "uid", time.Hour)
+	assert.NoError(t, err)
+	b, exp, err = ms.Exists(ctx, "uid")
 	log.Println(b, exp, err)
 	assert.True(t, b)
 	assert.False(t, exp.IsZero())
 }
 
 func TestRedisStoreVerify(t *testing.T) {
+	ctx := context.TODO()
 	ms := NewRedisStore(newRedisMock())
 	assert.NotNil(t, ms)
 
 	// Token doesn't exist
-	b, err := ms.Verify(nil, "badtoken", "uid")
+	b, err := ms.Verify(ctx, "badtoken", "uid")
 	assert.False(t, b)
 	assert.Equal(t, ErrTokenNotFound, err)
 
 	// Token expired
-	err = ms.Store(nil, "", "uid", -time.Hour)
-	b, err = ms.Verify(nil, "badtoken", "uid")
+	err = ms.Store(ctx, "", "uid", -time.Hour)
+	assert.NoError(t, err)
+	b, err = ms.Verify(ctx, "badtoken", "uid")
 	assert.False(t, b)
 	assert.Equal(t, ErrTokenNotFound, err)
 
 	// Token wrong
-	err = ms.Store(nil, "token", "uid", time.Hour)
-	b, err = ms.Verify(nil, "badtoken", "uid")
+	err = ms.Store(ctx, "token", "uid", time.Hour)
+	assert.NoError(t, err)
+	b, err = ms.Verify(ctx, "badtoken", "uid")
 	assert.False(t, b)
 	assert.NoError(t, err)
 
 	// Token correct
-	b, err = ms.Verify(nil, "token", "uid")
+	b, err = ms.Verify(ctx, "token", "uid")
 	assert.True(t, b)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
This change allows post verify actions to occur. For example you can now choose if a delete of a token should happen after its been validated.

I have also tidied up some `go vet` errors.